### PR TITLE
Add support for jwt 3.x

### DIFF
--- a/lib/omniauth/strategies/azure_activedirectory.rb
+++ b/lib/omniauth/strategies/azure_activedirectory.rb
@@ -328,9 +328,9 @@ module OmniAuth
               fail JWT::VerificationError,
                    'No keys from key endpoint match the id token'
             end
-            # The key also contains other fields, such as n and e, that are
-            # redundant. x5c is sufficient to verify the id token.
-            OpenSSL::X509::Certificate.new(JWT::Base64.url_decode(x5c.first)).public_key
+            # x5c uses standard Base64 (RFC 7517), not URL-safe Base64.
+            # JWT::Base64.url_decode is strict RFC 4648 in jwt 3.x and raises on '+' or '/'.
+            OpenSSL::X509::Certificate.new(::Base64.decode64(x5c.first)).public_key
           end
         return jwt_claims, jwt_header if jwt_claims['nonce'] == read_nonce
         fail JWT::DecodeError, 'Returned nonce did not match.'

--- a/lib/omniauth/strategies/azure_activedirectory.rb
+++ b/lib/omniauth/strategies/azure_activedirectory.rb
@@ -328,9 +328,9 @@ module OmniAuth
               fail JWT::VerificationError,
                    'No keys from key endpoint match the id token'
             end
-            # x5c uses standard Base64 (RFC 7517), not URL-safe Base64.
-            # JWT::Base64.url_decode is strict RFC 4648 in jwt 3.x and raises on '+' or '/'.
-            OpenSSL::X509::Certificate.new(::Base64.decode64(x5c.first)).public_key
+            # Normalise base64url to standard base64 (RFC 4648 §5, Table 2: '-' -> '+', '_' -> '/')
+            # before decoding. jwt 3.x dropped the lenient RFC 2045 fallback in url_decode.
+            OpenSSL::X509::Certificate.new(::Base64.decode64(x5c.first.tr('-_', '+/'))).public_key
           end
         return jwt_claims, jwt_header if jwt_claims['nonce'] == read_nonce
         fail JWT::DecodeError, 'Returned nonce did not match.'
@@ -361,13 +361,14 @@ module OmniAuth
       #
       # @return Hash
       def verify_options
-        { verify_expiration: true,
+        { algorithms: ['RS256'],
+          verify_expiration: true,
           verify_not_before: true,
           verify_iat: true,
           verify_iss: true,
-          'iss' => issuer,
+          iss: issuer,
           verify_aud: true,
-          'aud' => client_id }
+          aud: client_id }
       end
     end
   end

--- a/omniauth-azure-activedirectory.gemspec
+++ b/omniauth-azure-activedirectory.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files           = `git ls-files`.split("\n")
   s.require_paths   = ['lib']
 
-  s.add_runtime_dependency 'jwt', ['>= 2.2', '< 3.0']
+  s.add_runtime_dependency 'jwt', ['>= 2.2', '< 4.0']
   s.add_runtime_dependency 'omniauth', '~> 1.1'
 
   s.add_development_dependency 'rake', '~> 10.4'

--- a/omniauth-azure-activedirectory.gemspec
+++ b/omniauth-azure-activedirectory.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.3'
   s.add_development_dependency 'rubocop', '~> 0.32'
   s.add_development_dependency 'simplecov', '~> 0.10'
-  s.add_development_dependency 'webmock', '~> 1.21'
+  s.add_development_dependency 'webmock', '~> 3.0'
 end

--- a/spec/omniauth/strategies/azure_activedirectory_spec.rb
+++ b/spec/omniauth/strategies/azure_activedirectory_spec.rb
@@ -127,7 +127,7 @@ describe OmniAuth::Strategies::AzureActiveDirectory do
       #   { 'iss' => 'https://sts.imposter.net/bunch-of-random-chars', ... }
       #
       let(:id_token) { File.read(File.expand_path('../../../fixtures/id_token_bad_issuer.txt', __FILE__)) }
-      it { is_expected.to raise_error JWT::InvalidIssuerError }
+      it { expect { subject.call }.to raise_error JWT::InvalidIssuerError }
     end
 
     context 'with an invalid audience' do
@@ -135,7 +135,7 @@ describe OmniAuth::Strategies::AzureActiveDirectory do
       #   { 'aud' => 'not the client id', ... }
       #
       let(:id_token) { File.read(File.expand_path('../../../fixtures/id_token_bad_audience.txt', __FILE__)) }
-      it { is_expected.to raise_error JWT::InvalidAudError }
+      it { expect { subject.call }.to raise_error JWT::InvalidAudError }
     end
 
     context 'with a non-matching nonce' do
@@ -143,23 +143,23 @@ describe OmniAuth::Strategies::AzureActiveDirectory do
       #   { 'nonce' => 'not my nonce', ... }
       #
       let(:id_token) { File.read(File.expand_path('../../../fixtures/id_token_bad_nonce.txt', __FILE__)) }
-      it { is_expected.to raise_error JWT::DecodeError }
+      it { expect { subject.call }.to raise_error JWT::DecodeError }
     end
 
     context 'with the wrong x5c' do
       let(:x5c) { File.read(File.expand_path('../../../fixtures/x5c_different.txt', __FILE__)) }
       let(:id_token) { File.read(File.expand_path('../../../fixtures/id_token.txt', __FILE__)) }
-      it { is_expected.to raise_error JWT::VerificationError }
+      it { expect { subject.call }.to raise_error JWT::VerificationError }
     end
 
     context 'with a non-matching c_hash' do
       let(:id_token) { File.read(File.expand_path('../../../fixtures/id_token_bad_chash.txt', __FILE__)) }
-      it { is_expected.to raise_error JWT::VerificationError }
+      it { expect { subject.call }.to raise_error JWT::VerificationError }
     end
 
     context 'with a non-matching kid' do
       let(:id_token) { File.read(File.expand_path('../../../fixtures/id_token_bad_kid.txt', __FILE__)) }
-      it { is_expected.to raise_error JWT::VerificationError }
+      it { expect { subject.call }.to raise_error JWT::VerificationError }
     end
 
     context 'with no alg header' do


### PR DESCRIPTION
### Fix jwt 3.x compatibility

Fixes compatibility with jwt 3.x so that sf-auth can upgrade from jwt 2.10.2 to 3.2.0 (see https://gitlab.silverfin.com/development/silverfin/-/work_items/32305).

### Changes

`omniauth-azure-activedirectory.gemspec`:
  - Relax `jwt` constraint from < 3.0 to < 4.0
  - Bump `webmock` from ~> 1.21 to ~> 3.0 — webmock 1.x's StubSocket is missing the close method called by Ruby 3.x's `Net::HTTP`, causing all stubbed HTTP calls in the test suite to fail

Three breaking changes in `lib/omniauth/strategies/azure_activedirectory.rb`:
  - x5c decoding — `JWT::Base64.url_decode` is now strict RFC 4648 and raises on `+` or `/` characters in standard base64-encoded DER certificates. Replaced with `::Base64.decode64(x5c.first.tr('-_', '+/'))`, which normalises base64url to standard base64 per [RFC 4648 §5 Table 2](https://datatracker.ietf.org/doc/html/rfc4648#section-5) before decoding, handling both encodings.
  - Algorithm must be declared explicitly — jwt 3.x requires algorithms: in the decode options. Added algorithms:
  `['RS256']` to verify_options.
  - Symbol keys required for claim options — jwt 3.x ignores string-keyed options ('iss' =>, 'aud' =>), silently
  skipping issuer and audience validation. Changed to symbol keys (iss:, aud:).

`spec/omniauth/strategies/azure_activedirectory_spec.rb`:
  - Fixed RSpec deprecation warnings: `is_expected.to raise_error X` → `expect { subject.call }.to raise_error X`